### PR TITLE
Adding Metric Server Module

### DIFF
--- a/modules/metrics-server/main.tf
+++ b/modules/metrics-server/main.tf
@@ -1,0 +1,27 @@
+locals {
+  values = yamlencode({
+
+    apiService = {
+      create = true
+    }
+
+    hostNetwork = {
+      enabled = true
+    }
+
+    metrics = {
+      enabled = true
+    }
+
+  })
+}
+
+resource "helm_release" "this" {
+  chart      = "metrics-server"
+  name       = var.release_name
+  namespace  = var.namespace
+  repository = "https://charts.bitnami.com/bitnami"
+  values     = [local.values]
+  version    = var.release_version
+  replace    = true
+}

--- a/modules/metrics-server/variables.tf
+++ b/modules/metrics-server/variables.tf
@@ -1,0 +1,14 @@
+variable "namespace" {
+  default = "kube-system"
+  type    = string
+}
+
+variable "release_name" {
+  default = "metrics-server"
+  type    = string
+}
+
+variable "release_version" {
+  default = "6.0.0"
+  type    = string
+}


### PR DESCRIPTION
* Including Metric Servers module
* Allows Control Plane Nodes to talk to Worker nodes on all ports. Added this to simplify issues with Add-ons communication with Control plane: metrics-server 4443, spark-operator 8080, karpenter 8443 etc. (it can be adjusted to your security requirements if needed)




PS: Sorry for the formatting of the code (spaces), Visual Studio Code Prettier extension might differ with you IntelljIDEA